### PR TITLE
SCMOD-7472: opensuse-base image version updated

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM cafapi/opensuse-base:1
+FROM cafinternal/prereleases:opensuse-base-1.3.0-SCMOD-7472-SNAPSHOT
 
 # Update the OS packages and install NodeJS
 RUN zypper -n refresh && \


### PR DESCRIPTION


http://sou-jenkins2.hpeswlab.net/job/CAFapi/job/CAFapi~opensuse-nodejs8-image~SCMOD-7472~CI/